### PR TITLE
Fix required for on-http dynamic discovery

### DIFF
--- a/lib/services/workflow-api-service.js
+++ b/lib/services/workflow-api-service.js
@@ -44,7 +44,11 @@ function workflowApiServiceFactory(
             }
         })
         .then(function () {
-            return taskgraphService.workflowsPost(configuration, nodeId);
+            if(nodeId !== null){
+                return taskgraphService.workflowsPost(configuration,nodeId);
+            } else {
+                  return taskgraphService.workflowsPost(configuration);
+            }
         });
 
     };


### PR DESCRIPTION
- can't pass empty object to grpc

@brianparry 